### PR TITLE
feat(footer): implement Footer component

### DIFF
--- a/v2/src/components/layout/Footer.astro
+++ b/v2/src/components/layout/Footer.astro
@@ -1,9 +1,77 @@
 ---
-// Footer: Copyright + Social Links + Resume Download
+import { getLangFromUrl, getTranslations } from '@/i18n/utils';
+import socialData from '@/data/social.json';
+
+const lang = getLangFromUrl(Astro.url);
+const t = await getTranslations(lang);
+const currentYear = new Date().getFullYear();
+
+const socialIcons: Record<string, string> = {
+  github: `<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>`,
+  linkedin: `<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>`,
+  twitter: `<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>`,
+};
 ---
 
-<footer class="border-border border-t py-12">
-  <div class="text-muted-foreground mx-auto max-w-6xl px-6 text-center text-sm">
-    <p>[ Footer — Social Links | Resume Download | Copyright ]</p>
+<footer class="border-border border-t pt-12 pb-24 md:pb-12">
+  <div class="mx-auto max-w-6xl px-6">
+    <!-- SNS Links -->
+    <div class="mb-8 flex justify-center gap-6">
+      {
+        socialData.links.map((link) => (
+          <a
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={link.name}
+            title={link.name}
+            class="text-muted-foreground hover:text-foreground transition-colors"
+            set:html={socialIcons[link.icon] ?? ''}
+          />
+        ))
+      }
+    </div>
+
+    <!-- Bottom row: copyright / resume / back to top -->
+    <div
+      class="text-muted-foreground flex flex-col items-center gap-4 text-sm sm:flex-row sm:justify-between"
+    >
+      <p>© {currentYear} Ryota Nakamura</p>
+
+      <a
+        href="/resume.pdf"
+        download
+        class="hover:text-foreground flex items-center gap-1.5 transition-colors"
+      >
+        <svg
+          class="h-4 w-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1.5"
+            d="M12 10v6m0 0-3-3m3 3 3-3M3 17v2a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-2"></path>
+        </svg>
+        {t('footer.resume')}
+      </a>
+
+      <a href="#hero" class="hover:text-foreground flex items-center gap-1.5 transition-colors">
+        {t('footer.backToTop')}
+        <svg
+          class="h-4 w-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 15l7-7 7 7"
+          ></path>
+        </svg>
+      </a>
+    </div>
   </div>
 </footer>

--- a/v2/src/components/layout/Footer.astro
+++ b/v2/src/components/layout/Footer.astro
@@ -6,6 +6,7 @@ const lang = getLangFromUrl(Astro.url);
 const t = await getTranslations(lang);
 const currentYear = new Date().getFullYear();
 
+// SVG strings are build-time constants — set:html is safe as long as this map stays internal
 const socialIcons: Record<string, string> = {
   github: `<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>`,
   linkedin: `<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>`,
@@ -13,7 +14,7 @@ const socialIcons: Record<string, string> = {
 };
 ---
 
-<footer class="pb-12 md:pb-24">
+<footer class="pb-12 md:pb-24" aria-label="Site footer">
   <!-- Gradient border top -->
   <div class="h-px w-full bg-gradient-to-r from-[#686dff] to-[#b66fff]"></div>
   <div class="mx-auto max-w-6xl px-6 pt-12">
@@ -25,7 +26,7 @@ const socialIcons: Record<string, string> = {
             href={link.url}
             target="_blank"
             rel="noopener noreferrer"
-            aria-label={link.name}
+            aria-label={`${link.name} (opens in new tab)`}
             title={link.name}
             class="text-muted-foreground hover:text-foreground transition-colors"
             set:html={socialIcons[link.icon] ?? ''}

--- a/v2/src/components/layout/Footer.astro
+++ b/v2/src/components/layout/Footer.astro
@@ -13,8 +13,10 @@ const socialIcons: Record<string, string> = {
 };
 ---
 
-<footer class="border-border border-t pt-12 pb-12 md:pb-28">
-  <div class="mx-auto max-w-6xl px-6">
+<footer class="pb-12 md:pb-24">
+  <!-- Gradient border top -->
+  <div class="h-px w-full bg-gradient-to-r from-[#686dff] to-[#b66fff]"></div>
+  <div class="mx-auto max-w-6xl px-6 pt-12">
     <!-- SNS Links -->
     <div class="mb-8 flex justify-center gap-6">
       {
@@ -32,32 +34,9 @@ const socialIcons: Record<string, string> = {
       }
     </div>
 
-    <!-- Bottom row: copyright / resume / back to top -->
-    <div
-      class="text-muted-foreground flex flex-col items-center gap-4 text-sm sm:flex-row sm:justify-between"
-    >
+    <!-- Bottom row: copyright / back to top -->
+    <div class="text-muted-foreground flex items-center justify-between text-sm">
       <p>© {currentYear} Ryota Nakamura</p>
-
-      <a
-        href="/resume.pdf"
-        download
-        class="hover:text-foreground flex items-center gap-1.5 transition-colors"
-      >
-        <svg
-          class="h-4 w-4"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="1.5"
-            d="M12 10v6m0 0-3-3m3 3 3-3M3 17v2a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-2"></path>
-        </svg>
-        {t('footer.resume')}
-      </a>
 
       <a href="#hero" class="hover:text-foreground flex items-center gap-1.5 transition-colors">
         {t('footer.backToTop')}

--- a/v2/src/components/layout/Footer.astro
+++ b/v2/src/components/layout/Footer.astro
@@ -13,7 +13,7 @@ const socialIcons: Record<string, string> = {
 };
 ---
 
-<footer class="border-border border-t pt-12 pb-24 md:pb-12">
+<footer class="border-border border-t pt-12 pb-12 md:pb-28">
   <div class="mx-auto max-w-6xl px-6">
     <!-- SNS Links -->
     <div class="mb-8 flex justify-center gap-6">

--- a/v2/src/i18n/locales/en.json
+++ b/v2/src/i18n/locales/en.json
@@ -18,5 +18,7 @@
   "header.theme.light": "Light",
   "header.theme.dark": "Dark",
   "header.lang": "日本語",
-  "header.menu": "Menu"
+  "header.menu": "Menu",
+  "footer.resume": "Download Résumé",
+  "footer.backToTop": "Back to Top"
 }

--- a/v2/src/i18n/locales/en.json
+++ b/v2/src/i18n/locales/en.json
@@ -19,6 +19,5 @@
   "header.theme.dark": "Dark",
   "header.lang": "日本語",
   "header.menu": "Menu",
-  "footer.resume": "Download Résumé",
   "footer.backToTop": "Back to Top"
 }

--- a/v2/src/i18n/locales/ja.json
+++ b/v2/src/i18n/locales/ja.json
@@ -19,6 +19,5 @@
   "header.theme.dark": "ダーク",
   "header.lang": "English",
   "header.menu": "メニュー",
-  "footer.resume": "履歴書をダウンロード",
   "footer.backToTop": "トップへ戻る"
 }

--- a/v2/src/i18n/locales/ja.json
+++ b/v2/src/i18n/locales/ja.json
@@ -18,5 +18,7 @@
   "header.theme.light": "ライト",
   "header.theme.dark": "ダーク",
   "header.lang": "English",
-  "header.menu": "メニュー"
+  "header.menu": "メニュー",
+  "footer.resume": "履歴書をダウンロード",
+  "footer.backToTop": "トップへ戻る"
 }

--- a/v2/src/i18n/utils.ts
+++ b/v2/src/i18n/utils.ts
@@ -9,7 +9,8 @@ export const defaultLang: Lang = 'en';
 
 export function getLangFromUrl(url: URL): Lang {
   const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-  const path = base && url.pathname.startsWith(base) ? url.pathname.slice(base.length) : url.pathname;
+  const path =
+    base && url.pathname.startsWith(base) ? url.pathname.slice(base.length) : url.pathname;
   const [, lang] = path.split('/');
   if (lang in languages) return lang as Lang;
   return defaultLang;


### PR DESCRIPTION
## Summary

- フッターコンポーネントを実装（SNSリンク、コピーライト、Back to Top）
- OmniCoreブランドグラデーションライン（`#686dff → #b66fff`）でページを締める
- DockNav（デスクトップ固定）との重なりを回避するパディング調整

## 変更詳細

- `Footer.astro`: コピーライト・SNSリンク（social.jsonから取得）・Back to Topを実装
- グラデーションボーダー（`border-t` → グラデーションライン `h-px`）に変更
- `pb-12 md:pb-24`: モバイルはシンプル、デスクトップはDockNav分の余白を確保
- `aria-label` / `opens in new tab` でアクセシビリティ対応
- `footer.backToTop` i18n キーを en/ja に追加

## Test plan

- [x] デスクトップ（md以上）でフッターとDockNavが重ならないことを確認
- [x] モバイルでフッターが正常に表示されることを確認
- [x] グラデーションラインがライト/ダーク両モードで表示されることを確認
- [x] Back to Topリンクが`#hero`にスクロールすることを確認
- [x] EN/JA両言語でBack to Topテキストが正しく表示されることを確認