### PR TITLE
feat(skills): implement Skills section

### DIFF
--- a/v2/src/components/skills/SkillsGrid.tsx
+++ b/v2/src/components/skills/SkillsGrid.tsx
@@ -1,0 +1,125 @@
+import { motion } from 'motion/react';
+
+interface Skill {
+  name: string;
+  icon: string;
+}
+
+interface Category {
+  name: string;
+  skills: Skill[];
+}
+
+interface Props {
+  categories: Category[];
+}
+
+// devicon CDN base URL
+const DEVICON_BASE = 'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons';
+
+// Map from JSON icon key → devicon path segment (icon-name/icon-name-variant.svg)
+const DEVICON_MAP: Record<string, string> = {
+  html5: 'html5/html5-original.svg',
+  css3: 'css3/css3-original.svg',
+  javascript: 'javascript/javascript-original.svg',
+  react: 'react/react-original.svg',
+  typescript: 'typescript/typescript-original.svg',
+  ruby: 'ruby/ruby-original.svg',
+  python: 'python/python-original.svg',
+  nodejs: 'nodejs/nodejs-original.svg',
+  rails: 'rails/rails-plain-wordmark.svg',
+  django: 'django/django-plain.svg',
+  aws: 'amazonwebservices/amazonwebservices-plain-wordmark.svg',
+  gcp: 'googlecloud/googlecloud-original.svg',
+  kubernetes: 'kubernetes/kubernetes-plain.svg',
+  docker: 'docker/docker-original.svg',
+  cplusplus: 'cplusplus/cplusplus-original.svg',
+  google: 'google/google-original.svg',
+};
+
+function getIconUrl(icon: string): string | null {
+  const path = DEVICON_MAP[icon];
+  if (!path) return null;
+  return `${DEVICON_BASE}/${path}`;
+}
+
+const containerVariants = {
+  hidden: {},
+  visible: {
+    transition: {
+      staggerChildren: 0.08,
+    },
+  },
+};
+
+const categoryVariants = {
+  hidden: { opacity: 0, y: 24 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.5, ease: [0.25, 0.46, 0.45, 0.94] },
+  },
+};
+
+const skillVariants = {
+  hidden: { opacity: 0, scale: 0.92 },
+  visible: {
+    opacity: 1,
+    scale: 1,
+    transition: { duration: 0.3, ease: 'easeOut' },
+  },
+};
+
+export default function SkillsGrid({ categories }: Props) {
+  return (
+    <motion.div
+      variants={containerVariants}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, margin: '-80px' }}
+      className="grid gap-10 md:grid-cols-2"
+    >
+      {categories.map((category) => (
+        <motion.div key={category.name} variants={categoryVariants}>
+          {/* Category heading */}
+          <h3 className="text-muted-foreground mb-4 text-xs font-semibold tracking-widest uppercase">
+            {category.name}
+          </h3>
+
+          {/* Skills grid */}
+          <motion.div
+            variants={containerVariants}
+            className="flex flex-wrap gap-3"
+          >
+            {category.skills.map((skill) => {
+              const iconUrl = getIconUrl(skill.icon);
+              return (
+                <motion.div
+                  key={skill.name}
+                  variants={skillVariants}
+                  className="border-border bg-card hover:border-[#686dff]/40 hover:bg-[rgba(104,109,255,0.04)] flex items-center gap-2 rounded-lg border px-3 py-2 transition-colors"
+                >
+                  {iconUrl ? (
+                    <img
+                      src={iconUrl}
+                      alt={skill.name}
+                      width={20}
+                      height={20}
+                      className="size-5 shrink-0 object-contain"
+                      loading="lazy"
+                    />
+                  ) : (
+                    <span className="text-[#686dff] size-5 shrink-0 text-center text-xs font-bold leading-5">
+                      {skill.name.slice(0, 2).toUpperCase()}
+                    </span>
+                  )}
+                  <span className="text-foreground text-sm font-medium">{skill.name}</span>
+                </motion.div>
+              );
+            })}
+          </motion.div>
+        </motion.div>
+      ))}
+    </motion.div>
+  );
+}

--- a/v2/src/components/skills/SkillsGrid.tsx
+++ b/v2/src/components/skills/SkillsGrid.tsx
@@ -98,7 +98,7 @@ export default function SkillsGrid({ categories }: Props) {
                 <motion.div
                   key={skill.name}
                   variants={skillVariants}
-                  className="border-border bg-card hover:border-[#686dff]/40 hover:bg-[#686dff]/[0.04] flex items-center gap-2 rounded-lg border px-3 py-2 transition-colors"
+                  className="border-border bg-card flex items-center gap-2 rounded-lg border px-3 py-2 transition-colors hover:border-[#686dff]/40 hover:bg-[#686dff]/[0.04]"
                 >
                   {iconUrl ? (
                     <img
@@ -112,7 +112,7 @@ export default function SkillsGrid({ categories }: Props) {
                   ) : (
                     <span
                       aria-hidden="true"
-                      className="text-[#686dff] size-5 shrink-0 text-center text-xs font-bold leading-5"
+                      className="size-5 shrink-0 text-center text-xs leading-5 font-bold text-[#686dff]"
                     >
                       {skill.name.slice(0, 2).toUpperCase()}
                     </span>

--- a/v2/src/components/skills/SkillsGrid.tsx
+++ b/v2/src/components/skills/SkillsGrid.tsx
@@ -14,27 +14,30 @@ interface Props {
   categories: Category[];
 }
 
-// devicon CDN base URL
-const DEVICON_BASE = 'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons';
+// Pinned to a stable release to avoid breaking icon path changes
+const DEVICON_BASE = 'https://cdn.jsdelivr.net/gh/devicons/devicon@v2.16.0/icons';
 
-// Map from JSON icon key → devicon path segment (icon-name/icon-name-variant.svg)
+// Map from JSON icon key → devicon path segment
+// If an icon key is not listed here, a text initials badge is shown as fallback.
 const DEVICON_MAP: Record<string, string> = {
   html5: 'html5/html5-original.svg',
   css3: 'css3/css3-original.svg',
   javascript: 'javascript/javascript-original.svg',
   react: 'react/react-original.svg',
   typescript: 'typescript/typescript-original.svg',
-  ruby: 'ruby/ruby-original.svg',
   python: 'python/python-original.svg',
+  fastapi: 'fastapi/fastapi-original.svg',
   nodejs: 'nodejs/nodejs-original.svg',
   rails: 'rails/rails-plain-wordmark.svg',
-  django: 'django/django-plain.svg',
+  mongodb: 'mongodb/mongodb-original.svg',
+  scala: 'scala/scala-original.svg',
+  apachespark: 'apachespark/apachespark-original.svg',
   aws: 'amazonwebservices/amazonwebservices-plain-wordmark.svg',
+  azure: 'azure/azure-original.svg',
   gcp: 'googlecloud/googlecloud-original.svg',
-  kubernetes: 'kubernetes/kubernetes-plain.svg',
   docker: 'docker/docker-original.svg',
+  kubernetes: 'kubernetes/kubernetes-plain.svg',
   cplusplus: 'cplusplus/cplusplus-original.svg',
-  google: 'google/google-original.svg',
 };
 
 function getIconUrl(icon: string): string | null {
@@ -86,30 +89,30 @@ export default function SkillsGrid({ categories }: Props) {
             {category.name}
           </h3>
 
-          {/* Skills grid */}
-          <motion.div
-            variants={containerVariants}
-            className="flex flex-wrap gap-3"
-          >
+          {/* Skills pills */}
+          <motion.div variants={containerVariants} className="flex flex-wrap gap-3">
             {category.skills.map((skill) => {
               const iconUrl = getIconUrl(skill.icon);
               return (
                 <motion.div
                   key={skill.name}
                   variants={skillVariants}
-                  className="border-border bg-card hover:border-[#686dff]/40 hover:bg-[rgba(104,109,255,0.04)] flex items-center gap-2 rounded-lg border px-3 py-2 transition-colors"
+                  className="border-border bg-card hover:border-[#686dff]/40 hover:bg-[#686dff]/[0.04] flex items-center gap-2 rounded-lg border px-3 py-2 transition-colors"
                 >
                   {iconUrl ? (
                     <img
                       src={iconUrl}
-                      alt={skill.name}
+                      alt=""
                       width={20}
                       height={20}
                       className="size-5 shrink-0 object-contain"
                       loading="lazy"
                     />
                   ) : (
-                    <span className="text-[#686dff] size-5 shrink-0 text-center text-xs font-bold leading-5">
+                    <span
+                      aria-hidden="true"
+                      className="text-[#686dff] size-5 shrink-0 text-center text-xs font-bold leading-5"
+                    >
                       {skill.name.slice(0, 2).toUpperCase()}
                     </span>
                   )}

--- a/v2/src/components/skills/SkillsGrid.tsx
+++ b/v2/src/components/skills/SkillsGrid.tsx
@@ -29,6 +29,7 @@ const DEVICON_MAP: Record<string, string> = {
   fastapi: 'fastapi/fastapi-original.svg',
   nodejs: 'nodejs/nodejs-original.svg',
   rails: 'rails/rails-plain-wordmark.svg',
+  java: 'java/java-original.svg',
   mongodb: 'mongodb/mongodb-original.svg',
   scala: 'scala/scala-original.svg',
   apachespark: 'apachespark/apachespark-original.svg',

--- a/v2/src/components/skills/SkillsSection.astro
+++ b/v2/src/components/skills/SkillsSection.astro
@@ -1,12 +1,23 @@
 ---
-// Skills: Technical stack by category
+import { getLangFromUrl, getTranslations } from '@/i18n/utils';
+import SkillsGrid from './SkillsGrid';
+
+const lang = getLangFromUrl(Astro.url);
+const t = await getTranslations(lang);
+
+const skillsData = await import(`../../data/${lang}/skills.json`);
+const categories = skillsData.categories ?? skillsData.default?.categories ?? [];
 ---
 
 <section id="skills" class="py-24">
   <div class="mx-auto max-w-6xl px-6">
-    <h2 class="text-4xl font-semibold">Skills</h2>
-    <p class="text-muted-foreground mt-4">
-      [ Skills — Category Grid: Languages | Frameworks | Tools | Cloud ]
-    </p>
+    <!-- Section heading -->
+    <div class="mb-16">
+      <h2 class="text-foreground text-3xl font-semibold md:text-4xl">{t('skills.title')}</h2>
+      <p class="text-muted-foreground mt-3 text-base">{t('skills.subtitle')}</p>
+    </div>
+
+    <!-- Animated grid (client:visible = hydrate when scrolled into view) -->
+    <SkillsGrid client:visible categories={categories} />
   </div>
 </section>

--- a/v2/src/data/en/skills.json
+++ b/v2/src/data/en/skills.json
@@ -17,6 +17,7 @@
         { "name": "FastAPI", "icon": "fastapi" },
         { "name": "Node.js", "icon": "nodejs" },
         { "name": "Ruby on Rails", "icon": "rails" },
+        { "name": "Java", "icon": "java" },
         { "name": "MongoDB", "icon": "mongodb" }
       ]
     },

--- a/v2/src/data/en/skills.json
+++ b/v2/src/data/en/skills.json
@@ -3,38 +3,55 @@
     {
       "name": "Frontend",
       "skills": [
-        { "name": "HTML", "icon": "html5" },
-        { "name": "CSS", "icon": "css3" },
-        { "name": "JavaScript", "icon": "javascript" },
         { "name": "React", "icon": "react" },
-        { "name": "TypeScript", "icon": "typescript" }
+        { "name": "TypeScript", "icon": "typescript" },
+        { "name": "JavaScript", "icon": "javascript" },
+        { "name": "HTML", "icon": "html5" },
+        { "name": "CSS", "icon": "css3" }
       ]
     },
     {
-      "name": "Backend",
+      "name": "Backend & API",
       "skills": [
-        { "name": "Ruby", "icon": "ruby" },
         { "name": "Python", "icon": "python" },
+        { "name": "FastAPI", "icon": "fastapi" },
         { "name": "Node.js", "icon": "nodejs" },
-        { "name": "Rails", "icon": "rails" },
-        { "name": "Django", "icon": "django" }
+        { "name": "Ruby on Rails", "icon": "rails" },
+        { "name": "MongoDB", "icon": "mongodb" }
       ]
     },
     {
-      "name": "System/DevOps",
+      "name": "AI / GenAI",
+      "skills": [
+        { "name": "LangChain", "icon": "langchain" },
+        { "name": "OpenAI Agents SDK", "icon": "openai" },
+        { "name": "RAG Pipeline", "icon": "rag" },
+        { "name": "ChromaDB", "icon": "chromadb" },
+        { "name": "LangSmith", "icon": "langsmith" }
+      ]
+    },
+    {
+      "name": "Big Data",
+      "skills": [
+        { "name": "Apache Spark", "icon": "apachespark" },
+        { "name": "PySpark", "icon": "pyspark" },
+        { "name": "Scala", "icon": "scala" }
+      ]
+    },
+    {
+      "name": "Cloud & DevOps",
       "skills": [
         { "name": "AWS", "icon": "aws" },
+        { "name": "Azure", "icon": "azure" },
         { "name": "GCP", "icon": "gcp" },
-        { "name": "Kubernetes", "icon": "kubernetes" },
         { "name": "Docker", "icon": "docker" },
-        { "name": "CI/CD", "icon": "cicd" }
+        { "name": "Kubernetes", "icon": "kubernetes" }
       ]
     },
     {
-      "name": "Languages/Tools",
+      "name": "Robotics",
       "skills": [
         { "name": "C++", "icon": "cplusplus" },
-        { "name": "GAS", "icon": "google" },
         { "name": "ROS", "icon": "ros" }
       ]
     }

--- a/v2/src/data/en/skills.json
+++ b/v2/src/data/en/skills.json
@@ -36,7 +36,8 @@
       "skills": [
         { "name": "Apache Spark", "icon": "apachespark" },
         { "name": "PySpark", "icon": "pyspark" },
-        { "name": "Scala", "icon": "scala" }
+        { "name": "Scala", "icon": "scala" },
+        { "name": "Treasure Data", "icon": "treasuredata" }
       ]
     },
     {

--- a/v2/src/data/ja/skills.json
+++ b/v2/src/data/ja/skills.json
@@ -17,6 +17,7 @@
         { "name": "FastAPI", "icon": "fastapi" },
         { "name": "Node.js", "icon": "nodejs" },
         { "name": "Ruby on Rails", "icon": "rails" },
+        { "name": "Java", "icon": "java" },
         { "name": "MongoDB", "icon": "mongodb" }
       ]
     },

--- a/v2/src/data/ja/skills.json
+++ b/v2/src/data/ja/skills.json
@@ -3,38 +3,55 @@
     {
       "name": "フロントエンド",
       "skills": [
-        { "name": "HTML", "icon": "html5" },
-        { "name": "CSS", "icon": "css3" },
-        { "name": "JavaScript", "icon": "javascript" },
         { "name": "React", "icon": "react" },
-        { "name": "TypeScript", "icon": "typescript" }
+        { "name": "TypeScript", "icon": "typescript" },
+        { "name": "JavaScript", "icon": "javascript" },
+        { "name": "HTML", "icon": "html5" },
+        { "name": "CSS", "icon": "css3" }
       ]
     },
     {
-      "name": "バックエンド",
+      "name": "バックエンド & API",
       "skills": [
-        { "name": "Ruby", "icon": "ruby" },
         { "name": "Python", "icon": "python" },
+        { "name": "FastAPI", "icon": "fastapi" },
         { "name": "Node.js", "icon": "nodejs" },
-        { "name": "Rails", "icon": "rails" },
-        { "name": "Django", "icon": "django" }
+        { "name": "Ruby on Rails", "icon": "rails" },
+        { "name": "MongoDB", "icon": "mongodb" }
       ]
     },
     {
-      "name": "システム/DevOps",
+      "name": "AI / 生成AI",
+      "skills": [
+        { "name": "LangChain", "icon": "langchain" },
+        { "name": "OpenAI Agents SDK", "icon": "openai" },
+        { "name": "RAGパイプライン", "icon": "rag" },
+        { "name": "ChromaDB", "icon": "chromadb" },
+        { "name": "LangSmith", "icon": "langsmith" }
+      ]
+    },
+    {
+      "name": "ビッグデータ",
+      "skills": [
+        { "name": "Apache Spark", "icon": "apachespark" },
+        { "name": "PySpark", "icon": "pyspark" },
+        { "name": "Scala", "icon": "scala" }
+      ]
+    },
+    {
+      "name": "クラウド & DevOps",
       "skills": [
         { "name": "AWS", "icon": "aws" },
+        { "name": "Azure", "icon": "azure" },
         { "name": "GCP", "icon": "gcp" },
-        { "name": "Kubernetes", "icon": "kubernetes" },
         { "name": "Docker", "icon": "docker" },
-        { "name": "CI/CD", "icon": "cicd" }
+        { "name": "Kubernetes", "icon": "kubernetes" }
       ]
     },
     {
-      "name": "言語/ツール",
+      "name": "ロボティクス",
       "skills": [
         { "name": "C++", "icon": "cplusplus" },
-        { "name": "GAS", "icon": "google" },
         { "name": "ROS", "icon": "ros" }
       ]
     }

--- a/v2/src/data/ja/skills.json
+++ b/v2/src/data/ja/skills.json
@@ -36,7 +36,8 @@
       "skills": [
         { "name": "Apache Spark", "icon": "apachespark" },
         { "name": "PySpark", "icon": "pyspark" },
-        { "name": "Scala", "icon": "scala" }
+        { "name": "Scala", "icon": "scala" },
+        { "name": "Treasure Data", "icon": "treasuredata" }
       ]
     },
     {

--- a/v2/src/i18n/locales/en.json
+++ b/v2/src/i18n/locales/en.json
@@ -18,5 +18,7 @@
   "header.theme.light": "Light",
   "header.theme.dark": "Dark",
   "header.lang": "日本語",
-  "header.menu": "Menu"
+  "header.menu": "Menu",
+  "skills.title": "Skills",
+  "skills.subtitle": "Technologies and tools I work with"
 }

--- a/v2/src/i18n/locales/ja.json
+++ b/v2/src/i18n/locales/ja.json
@@ -18,5 +18,7 @@
   "header.theme.light": "ライト",
   "header.theme.dark": "ダーク",
   "header.lang": "English",
-  "header.menu": "メニュー"
+  "header.menu": "メニュー",
+  "skills.title": "スキル",
+  "skills.subtitle": "使用している技術・ツール一覧"
 }

--- a/v2/src/i18n/utils.ts
+++ b/v2/src/i18n/utils.ts
@@ -9,7 +9,8 @@ export const defaultLang: Lang = 'en';
 
 export function getLangFromUrl(url: URL): Lang {
   const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-  const path = base && url.pathname.startsWith(base) ? url.pathname.slice(base.length) : url.pathname;
+  const path =
+    base && url.pathname.startsWith(base) ? url.pathname.slice(base.length) : url.pathname;
   const [, lang] = path.split('/');
   if (lang in languages) return lang as Lang;
   return defaultLang;


### PR DESCRIPTION
## Summary

- `SkillsSection.astro` + `SkillsGrid.tsx` で Skills セクションを実装（Motion whileInView スタッガーアニメーション）
- カテゴリを6つに整理: Frontend / Backend & API / AI GenAI / Big Data / Cloud & DevOps / Robotics
- FDE研修スキル（LangChain, OpenAI Agents SDK, RAG, Spark, Azure等）・Java・Treasure Data を追加

## 変更詳細

### コンポーネント
- `SkillsGrid.tsx` — React island（`client:visible`）。devicon CDN アイコン付きスキルピル、アイコン未対応はイニシャルバッジで表示
- `SkillsSection.astro` — i18n 対応の静的シェル（`data/{lang}/skills.json` を読み込み）

### データ整理
- 「Languages/Tools」（C++・GAS・ROS 混在）を廃止 → Robotics カテゴリとして明示
- GAS 削除（訴求力低）、Django → FastAPI + MongoDB に更新
- devicon CDN を `@v2.16.0` にピン留め

### アクセシビリティ
- `img alt=""` で装飾画像扱い、イニシャルバッジに `aria-hidden`
- `hover:bg-[#686dff]/[0.04]` で Tailwind opacity modifier に統一

## Test plan

- [ ] EN/JA 両言語でスキルカードが正しく表示される
- [ ] スクロール時にフェードインアニメーションが動作する
- [ ] devicon アイコンが表示される（未対応スキルはイニシャルバッジ）
- [ ] ライト/ダーク両モードで表示崩れがない
- [ ] `bun run build` が通る