### PR TITLE
fix: correct favicon href paths missing slash after BASE_URL

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -11,6 +11,7 @@ const lang = getLangFromUrl(Astro.url);
 const t = await getTranslations(lang);
 
 const { title = t('site.title'), description = t('site.description') } = Astro.props;
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 
 <!doctype html>
@@ -23,19 +24,10 @@ const { title = t('site.title'), description = t('site.description') } = Astro.p
     <meta name="author" content="Ryota Nakamura" />
 
     <!-- Favicons -->
-    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}favicon.svg`} />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href={`${import.meta.env.BASE_URL}favicon-32x32.png`}
-    />
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href={`${import.meta.env.BASE_URL}apple-touch-icon.png`}
-    />
-    <link rel="manifest" href={`${import.meta.env.BASE_URL}site.webmanifest`} />
+    <link rel="icon" type="image/svg+xml" href={`${base}/favicon.svg`} />
+    <link rel="icon" type="image/png" sizes="32x32" href={`${base}/favicon-32x32.png`} />
+    <link rel="apple-touch-icon" sizes="180x180" href={`${base}/apple-touch-icon.png`} />
+    <link rel="manifest" href={`${base}/site.webmanifest`} />
 
     <!-- hreflang for i18n SEO -->
     <link rel="alternate" hreflang="en" href="/en/" />


### PR DESCRIPTION
## Summary

- Fix favicon `<link>` href paths that were missing a `/` between `BASE_URL` and filename
- `BASE_URL` returns `/my_portfolio` (no trailing slash), causing `/my_portfoliofavicon.svg`
- Use same `base` variable pattern as `Header.astro` to produce `/my_portfolio/favicon.svg`

## Before / After

```
Before: /my_portfoliofavicon.svg
After:  /my_portfolio/favicon.svg
```