### PR TITLE
feat: cursor-tracked Border Glow on all cards (closes #32)

### DIFF
--- a/src/components/about/AboutSection.astro
+++ b/src/components/about/AboutSection.astro
@@ -85,7 +85,7 @@ const strengths: { name: string; subtitle?: string; desc: string }[] =
     <!-- MBTI Card -->
     {
       mbti && (
-        <div class="mbti-card bg-card border-border relative overflow-hidden rounded-2xl border p-6 md:p-8">
+        <div class="mbti-card border-glow bg-card border-border relative overflow-hidden rounded-2xl border p-6 md:p-8">
           <div class="pointer-events-none absolute -top-10 -right-10 h-40 w-40 rounded-full bg-[#686dff]/8 blur-3xl" />
 
           <div class="mb-6 flex items-start justify-between">
@@ -125,7 +125,7 @@ const strengths: { name: string; subtitle?: string; desc: string }[] =
 
     <!-- StrengthsFinder Card -->
     <div
-      class="sf-card bg-card border-border relative overflow-hidden rounded-2xl border p-6 md:p-8"
+      class="sf-card border-glow bg-card border-border relative overflow-hidden rounded-2xl border p-6 md:p-8"
     >
       <div
         class="pointer-events-none absolute -bottom-10 -left-10 h-40 w-40 rounded-full bg-[#b66fff]/8 blur-3xl"

--- a/src/components/achievements/AchievementsSection.astro
+++ b/src/components/achievements/AchievementsSection.astro
@@ -146,7 +146,7 @@ function getBentoPosition(index: number): string {
           <Tag
             {...linkProps}
             class:list={[
-              'group relative overflow-hidden rounded-2xl transition-shadow duration-300 hover:shadow-xl',
+              'border-glow group relative overflow-hidden rounded-2xl',
               sizeClasses[size],
               position,
             ]}

--- a/src/components/ai-toolkit/ToolGrid.tsx
+++ b/src/components/ai-toolkit/ToolGrid.tsx
@@ -51,8 +51,8 @@ function ToolIcon({ tool }: { tool: Tool }) {
       {/* Icon */}
       <div
         className={cn(
-          'border-border bg-card relative flex h-14 w-14 items-center justify-center overflow-hidden rounded-2xl border transition-all duration-200',
-          'group-hover:border-[#686dff]/50 group-hover:bg-[rgba(104,109,255,0.06)] group-hover:shadow-[0_8px_24px_rgba(104,109,255,0.18)]',
+          'group-border-glow border-border bg-card relative flex h-14 w-14 items-center justify-center overflow-hidden rounded-2xl border transition-all duration-200',
+          'group-hover:bg-[rgba(104,109,255,0.06)]',
         )}
       >
         {imgError ? (

--- a/src/components/common/SurfaceCard.astro
+++ b/src/components/common/SurfaceCard.astro
@@ -8,6 +8,7 @@ interface Props {
   padding?: 'none' | 'sm' | 'md' | 'lg';
   tone?: 'card' | 'background' | 'muted';
   interactive?: boolean;
+  glow?: boolean;
   class?: string;
 }
 
@@ -20,6 +21,7 @@ const {
   padding = 'md',
   tone = 'card',
   interactive = false,
+  glow = true,
   class: className = '',
 } = Astro.props;
 
@@ -57,6 +59,7 @@ const linkProps =
     paddingClass[padding],
     toneClass[tone],
     interactive && 'transition-shadow hover:shadow-md',
+    glow && 'border-glow',
     className,
   ]}
 >

--- a/src/components/media/MediaCarousel.tsx
+++ b/src/components/media/MediaCarousel.tsx
@@ -299,7 +299,7 @@ function MediaCard({ item, labels }: { item: MediaItem; labels: Record<string, s
   );
 
   const cardClass =
-    'border-border bg-background group w-72 shrink-0 overflow-hidden rounded-xl border transition-all duration-200 hover:border-[#686dff]/40 hover:shadow-lg';
+    'border-glow border-border bg-background group w-72 shrink-0 overflow-hidden rounded-xl border transition-all duration-200';
 
   if (!safeLink) {
     return (

--- a/src/components/media/MediaSection.astro
+++ b/src/components/media/MediaSection.astro
@@ -225,7 +225,7 @@ function formatDate(dateStr: string, locale: string): string {
             href={pressFeatured.link}
             target="_blank"
             rel="noopener noreferrer"
-            class="border-border bg-background group overflow-hidden rounded-2xl border transition-all duration-200 hover:border-[#686dff]/40 hover:shadow-xl md:flex"
+            class="border-glow border-border bg-background group overflow-hidden rounded-2xl border transition-all duration-200 md:flex"
           >
             {featuredThumb ? (
               <div
@@ -357,7 +357,7 @@ function formatDate(dateStr: string, locale: string): string {
                 href={item.link}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="border-border bg-background group flex-1 rounded-xl border p-5 transition-all duration-200 hover:border-[#686dff]/30 hover:shadow-sm"
+                class="border-glow border-border bg-background group flex-1 rounded-xl border p-5 transition-all duration-200"
               >
                 <div class="mb-3 flex flex-wrap items-center gap-2">
                   <PillBadge tone="primary">{formatDate(item.date, lang)}</PillBadge>

--- a/src/components/skills/SkillsGrid.tsx
+++ b/src/components/skills/SkillsGrid.tsx
@@ -98,7 +98,7 @@ export default function SkillsGrid({ categories }: Props) {
                 <motion.div
                   key={skill.name}
                   variants={skillVariants}
-                  className="border-border bg-card flex items-center gap-2 rounded-lg border px-3 py-2 transition-colors hover:border-[#686dff]/40 hover:bg-[#686dff]/[0.04]"
+                  className="border-glow border-border bg-card flex items-center gap-2 rounded-lg border px-3 py-2 transition-colors hover:bg-[#686dff]/[0.04]"
                 >
                   {iconUrl ? (
                     <img

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -52,5 +52,8 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
   </head>
   <body>
     <slot />
+    <script>
+      import '../scripts/border-glow';
+    </script>
   </body>
 </html>

--- a/src/scripts/border-glow.ts
+++ b/src/scripts/border-glow.ts
@@ -1,0 +1,42 @@
+// Cursor-tracked border glow.
+// Updates --glow-x / --glow-y CSS variables on `.border-glow` and
+// `.group-border-glow` elements as the pointer moves over them.
+//
+// Single document-level mousemove listener (event delegation), throttled
+// with requestAnimationFrame so we touch the DOM at most once per frame.
+
+let pending: PointerEvent | MouseEvent | null = null;
+let raf: number | null = null;
+
+function setVars(el: HTMLElement, e: { clientX: number; clientY: number }): void {
+  const rect = el.getBoundingClientRect();
+  el.style.setProperty('--glow-x', `${e.clientX - rect.left}px`);
+  el.style.setProperty('--glow-y', `${e.clientY - rect.top}px`);
+}
+
+function flush(): void {
+  raf = null;
+  const e = pending;
+  pending = null;
+  if (!e) return;
+  const target = e.target;
+  if (!(target instanceof Element)) return;
+
+  const direct = target.closest<HTMLElement>('.border-glow');
+  if (direct) setVars(direct, e);
+
+  const group = target.closest<HTMLElement>('.group');
+  if (group) {
+    const inner = group.querySelector<HTMLElement>('.group-border-glow');
+    if (inner) setVars(inner, e);
+  }
+}
+
+window.addEventListener(
+  'pointermove',
+  (e: PointerEvent) => {
+    pending = e;
+    if (raf === null) raf = requestAnimationFrame(flush);
+  },
+  { passive: true },
+);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -117,25 +117,32 @@
 }
 
 /* ===========================
-   Border Glow (hover only)
-   Brand-gradient ring + soft halo, mask-composited so it
-   replaces the existing 1px border on hover only.
+   Border Glow (hover only, cursor-tracked)
+   A radial brand-gradient at (--glow-x, --glow-y) is mask-composited
+   into a 1px ring, so only the slice of border nearest the cursor lights
+   up. Position is updated by src/scripts/border-glow.ts.
    =========================== */
 @layer components {
-  .border-glow {
+  .border-glow,
+  .group-border-glow {
     position: relative;
+    --glow-x: 50%;
+    --glow-y: 50%;
+    --glow-size: 220px;
     transition: box-shadow 280ms ease;
   }
-  .border-glow::before {
+  .border-glow::before,
+  .group-border-glow::before {
     content: '';
     position: absolute;
     inset: 0;
     padding: 1px;
     border-radius: inherit;
-    background: linear-gradient(
-      135deg,
+    background: radial-gradient(
+      var(--glow-size) circle at var(--glow-x) var(--glow-y),
       var(--color-brand) 0%,
-      var(--color-brand-purple) 100%
+      var(--color-brand-purple) 35%,
+      transparent 70%
     );
     -webkit-mask:
       linear-gradient(#fff 0 0) content-box,
@@ -143,7 +150,7 @@
     -webkit-mask-composite: xor;
     mask-composite: exclude;
     opacity: 0;
-    transition: opacity 280ms ease;
+    transition: opacity 200ms ease;
     pointer-events: none;
     z-index: 1;
   }
@@ -157,38 +164,13 @@
   .border-glow:focus-visible,
   .group:hover .group-border-glow,
   .group:focus-visible .group-border-glow {
-    box-shadow: 0 8px 32px -8px rgba(104, 109, 255, 0.32);
+    box-shadow: 0 8px 32px -8px rgba(104, 109, 255, 0.22);
   }
   .dark .border-glow:hover,
   .dark .border-glow:focus-visible,
   .dark .group:hover .group-border-glow,
   .dark .group:focus-visible .group-border-glow {
-    box-shadow: 0 8px 32px -6px rgba(104, 109, 255, 0.42);
-  }
-  .group-border-glow {
-    position: relative;
-    transition: box-shadow 280ms ease;
-  }
-  .group-border-glow::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    padding: 1px;
-    border-radius: inherit;
-    background: linear-gradient(
-      135deg,
-      var(--color-brand) 0%,
-      var(--color-brand-purple) 100%
-    );
-    -webkit-mask:
-      linear-gradient(#fff 0 0) content-box,
-      linear-gradient(#fff 0 0);
-    -webkit-mask-composite: xor;
-    mask-composite: exclude;
-    opacity: 0;
-    transition: opacity 280ms ease;
-    pointer-events: none;
-    z-index: 1;
+    box-shadow: 0 8px 32px -6px rgba(104, 109, 255, 0.32);
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -115,3 +115,102 @@
 .dark .hero-text {
   text-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
 }
+
+/* ===========================
+   Border Glow (hover only)
+   Brand-gradient ring + soft halo, mask-composited so it
+   replaces the existing 1px border on hover only.
+   =========================== */
+@layer components {
+  .border-glow {
+    position: relative;
+    transition: box-shadow 280ms ease;
+  }
+  .border-glow::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    padding: 1px;
+    border-radius: inherit;
+    background: linear-gradient(
+      135deg,
+      var(--color-brand) 0%,
+      var(--color-brand-purple) 100%
+    );
+    -webkit-mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    opacity: 0;
+    transition: opacity 280ms ease;
+    pointer-events: none;
+    z-index: 1;
+  }
+  .border-glow:hover::before,
+  .border-glow:focus-visible::before,
+  .group:hover .group-border-glow::before,
+  .group:focus-visible .group-border-glow::before {
+    opacity: 1;
+  }
+  .border-glow:hover,
+  .border-glow:focus-visible,
+  .group:hover .group-border-glow,
+  .group:focus-visible .group-border-glow {
+    box-shadow: 0 8px 32px -8px rgba(104, 109, 255, 0.32);
+  }
+  .dark .border-glow:hover,
+  .dark .border-glow:focus-visible,
+  .dark .group:hover .group-border-glow,
+  .dark .group:focus-visible .group-border-glow {
+    box-shadow: 0 8px 32px -6px rgba(104, 109, 255, 0.42);
+  }
+  .group-border-glow {
+    position: relative;
+    transition: box-shadow 280ms ease;
+  }
+  .group-border-glow::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    padding: 1px;
+    border-radius: inherit;
+    background: linear-gradient(
+      135deg,
+      var(--color-brand) 0%,
+      var(--color-brand-purple) 100%
+    );
+    -webkit-mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    opacity: 0;
+    transition: opacity 280ms ease;
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .border-glow,
+    .border-glow::before,
+    .group-border-glow,
+    .group-border-glow::before {
+      transition: none;
+    }
+    .border-glow::before,
+    .group-border-glow::before {
+      display: none;
+    }
+    .border-glow:hover,
+    .border-glow:focus-visible,
+    .dark .border-glow:hover,
+    .dark .border-glow:focus-visible,
+    .group:hover .group-border-glow,
+    .group:focus-visible .group-border-glow,
+    .dark .group:hover .group-border-glow,
+    .dark .group:focus-visible .group-border-glow {
+      box-shadow: none;
+    }
+  }
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -128,7 +128,7 @@
     position: relative;
     --glow-x: 50%;
     --glow-y: 50%;
-    --glow-size: 280px;
+    --glow-size: 260px;
     transition: box-shadow 280ms ease;
   }
   .border-glow::before,
@@ -136,13 +136,14 @@
     content: '';
     position: absolute;
     inset: 0;
-    padding: 1.5px;
+    padding: 2px;
     border-radius: inherit;
+    /* Light mode: vivid brand → purple, no white core (would vanish on white bg) */
     background: radial-gradient(
       var(--glow-size) circle at var(--glow-x) var(--glow-y),
-      #ffffff 0%,
-      var(--color-brand) 18%,
-      var(--color-brand-purple) 45%,
+      var(--color-brand) 0%,
+      var(--color-brand-purple) 30%,
+      rgba(182, 111, 255, 0.4) 55%,
       transparent 75%
     );
     -webkit-mask:
@@ -150,68 +151,60 @@
       linear-gradient(#fff 0 0);
     -webkit-mask-composite: xor;
     mask-composite: exclude;
+    /* Outward glow on the border ring itself */
+    filter: drop-shadow(0 0 4px rgba(104, 109, 255, 0.55));
     opacity: 0;
     transition: opacity 200ms ease;
     pointer-events: none;
     z-index: 1;
   }
-  .border-glow::after,
-  .group-border-glow::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
+  /* Dark mode: white-hot core for maximum pop on dark background */
+  .dark .border-glow::before,
+  .dark .group-border-glow::before {
     background: radial-gradient(
-      calc(var(--glow-size) * 0.6) circle at var(--glow-x) var(--glow-y),
-      rgba(255, 255, 255, 0.18) 0%,
-      rgba(104, 109, 255, 0.12) 35%,
-      transparent 70%
+      var(--glow-size) circle at var(--glow-x) var(--glow-y),
+      #ffffff 0%,
+      var(--color-brand) 22%,
+      var(--color-brand-purple) 50%,
+      transparent 78%
     );
-    opacity: 0;
-    transition: opacity 200ms ease;
-    pointer-events: none;
-    z-index: 0;
+    filter: drop-shadow(0 0 6px rgba(104, 109, 255, 0.7));
   }
   .border-glow:hover::before,
   .border-glow:focus-visible::before,
-  .border-glow:hover::after,
-  .border-glow:focus-visible::after,
   .group:hover .group-border-glow::before,
-  .group:focus-visible .group-border-glow::before,
-  .group:hover .group-border-glow::after,
-  .group:focus-visible .group-border-glow::after {
+  .group:focus-visible .group-border-glow::before {
     opacity: 1;
   }
+  /* Light mode: stronger brand-tinted ring + bigger halo for visibility on white */
   .border-glow:hover,
   .border-glow:focus-visible,
   .group:hover .group-border-glow,
   .group:focus-visible .group-border-glow {
     box-shadow:
-      0 0 0 1px rgba(104, 109, 255, 0.18),
-      0 12px 48px -6px rgba(104, 109, 255, 0.45);
+      0 0 0 1px rgba(104, 109, 255, 0.4),
+      0 4px 16px -2px rgba(104, 109, 255, 0.35),
+      0 16px 56px -8px rgba(182, 111, 255, 0.4);
   }
   .dark .border-glow:hover,
   .dark .border-glow:focus-visible,
   .dark .group:hover .group-border-glow,
   .dark .group:focus-visible .group-border-glow {
     box-shadow:
-      0 0 0 1px rgba(104, 109, 255, 0.28),
-      0 12px 48px -4px rgba(104, 109, 255, 0.6);
+      0 0 0 1px rgba(104, 109, 255, 0.35),
+      0 4px 20px -2px rgba(104, 109, 255, 0.5),
+      0 16px 56px -4px rgba(182, 111, 255, 0.55);
   }
 
   @media (prefers-reduced-motion: reduce) {
     .border-glow,
     .border-glow::before,
-    .border-glow::after,
     .group-border-glow,
-    .group-border-glow::before,
-    .group-border-glow::after {
+    .group-border-glow::before {
       transition: none;
     }
     .border-glow::before,
-    .border-glow::after,
-    .group-border-glow::before,
-    .group-border-glow::after {
+    .group-border-glow::before {
       display: none;
     }
     .border-glow:hover,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -128,7 +128,7 @@
     position: relative;
     --glow-x: 50%;
     --glow-y: 50%;
-    --glow-size: 220px;
+    --glow-size: 280px;
     transition: box-shadow 280ms ease;
   }
   .border-glow::before,
@@ -136,13 +136,14 @@
     content: '';
     position: absolute;
     inset: 0;
-    padding: 1px;
+    padding: 1.5px;
     border-radius: inherit;
     background: radial-gradient(
       var(--glow-size) circle at var(--glow-x) var(--glow-y),
-      var(--color-brand) 0%,
-      var(--color-brand-purple) 35%,
-      transparent 70%
+      #ffffff 0%,
+      var(--color-brand) 18%,
+      var(--color-brand-purple) 45%,
+      transparent 75%
     );
     -webkit-mask:
       linear-gradient(#fff 0 0) content-box,
@@ -154,34 +155,63 @@
     pointer-events: none;
     z-index: 1;
   }
+  .border-glow::after,
+  .group-border-glow::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(
+      calc(var(--glow-size) * 0.6) circle at var(--glow-x) var(--glow-y),
+      rgba(255, 255, 255, 0.18) 0%,
+      rgba(104, 109, 255, 0.12) 35%,
+      transparent 70%
+    );
+    opacity: 0;
+    transition: opacity 200ms ease;
+    pointer-events: none;
+    z-index: 0;
+  }
   .border-glow:hover::before,
   .border-glow:focus-visible::before,
+  .border-glow:hover::after,
+  .border-glow:focus-visible::after,
   .group:hover .group-border-glow::before,
-  .group:focus-visible .group-border-glow::before {
+  .group:focus-visible .group-border-glow::before,
+  .group:hover .group-border-glow::after,
+  .group:focus-visible .group-border-glow::after {
     opacity: 1;
   }
   .border-glow:hover,
   .border-glow:focus-visible,
   .group:hover .group-border-glow,
   .group:focus-visible .group-border-glow {
-    box-shadow: 0 8px 32px -8px rgba(104, 109, 255, 0.22);
+    box-shadow:
+      0 0 0 1px rgba(104, 109, 255, 0.18),
+      0 12px 48px -6px rgba(104, 109, 255, 0.45);
   }
   .dark .border-glow:hover,
   .dark .border-glow:focus-visible,
   .dark .group:hover .group-border-glow,
   .dark .group:focus-visible .group-border-glow {
-    box-shadow: 0 8px 32px -6px rgba(104, 109, 255, 0.32);
+    box-shadow:
+      0 0 0 1px rgba(104, 109, 255, 0.28),
+      0 12px 48px -4px rgba(104, 109, 255, 0.6);
   }
 
   @media (prefers-reduced-motion: reduce) {
     .border-glow,
     .border-glow::before,
+    .border-glow::after,
     .group-border-glow,
-    .group-border-glow::before {
+    .group-border-glow::before,
+    .group-border-glow::after {
       transition: none;
     }
     .border-glow::before,
-    .group-border-glow::before {
+    .border-glow::after,
+    .group-border-glow::before,
+    .group-border-glow::after {
       display: none;
     }
     .border-glow:hover,


### PR DESCRIPTION
## Summary

- 全カードにカーソル追従の Border Glow を導入
- ブランドカラー（`#686dff` → `#b66fff`）の radial gradient を mask-composite で 1px ボーダーリングに切り抜き、カーソル位置（`--glow-x` / `--glow-y`）に応じて発光部分が移動
- ライトモードはビビッドな brand → purple、ダークモードは白ホットコア。`drop-shadow` でボーダーエッジ自体を発光、3 層 box-shadow で halo
- `prefers-reduced-motion: reduce` で完全 off
- CSS ユーティリティ（`.border-glow` / `.group-border-glow`）+ 単一の delegated `pointermove` リスナー（rAF スロットル）

## 対象コンポーネント
- `SurfaceCard.astro` に `glow` prop（デフォルト on）→ Project / FeaturedProject / Contact が自動適用
- 個別適用: SkillsGrid / ToolGrid / MediaCarousel / MediaSection / AchievementsSection / AboutSection（MBTI, StrengthsFinder）

## Closes
Closes #32

## Test plan
- [ ] ライトモードで全カードにホバーし、カーソル追従の発光が確認できる
- [ ] ダークモードで白ホットスポット + ブランド色 halo が確認できる
- [ ] キーボード Tab で focus-visible 時にも発光する
- [ ] `prefers-reduced-motion: reduce` を OS 設定で有効化したとき発光が無効化される
- [ ] モバイル（タップのみ）で破綻しない
- [ ] `bun run lint` / `bun run build` 通過