### PR TITLE
fix(border-glow): address Copilot review on #33

### DIFF
--- a/src/components/common/SurfaceCard.astro
+++ b/src/components/common/SurfaceCard.astro
@@ -21,7 +21,11 @@ const {
   padding = 'md',
   tone = 'card',
   interactive = false,
-  glow = true,
+  // Default the hover glow only on cards that read as interactive surfaces:
+  // explicit `interactive`, anchor links, or `<article>` (used by card-grid
+  // items like ProjectCard). Plain `<div>` info cards must opt in with
+  // `glow={true}` so we don't suggest a click affordance that doesn't exist.
+  glow = interactive || as === 'a' || as === 'article',
   class: className = '',
 } = Astro.props;
 

--- a/src/components/contact/ContactSection.astro
+++ b/src/components/contact/ContactSection.astro
@@ -18,7 +18,7 @@ const t = await getTranslations(lang);
 
   <div class="grid gap-12 md:grid-cols-2">
     <!-- Availability -->
-    <SurfaceCard padding="lg" tone="background">
+    <SurfaceCard padding="lg" tone="background" glow>
       <div class="mb-4 flex items-center gap-3">
         <span class="relative flex h-3 w-3">
           <span
@@ -37,7 +37,7 @@ const t = await getTranslations(lang);
     </SurfaceCard>
 
     <!-- Social Links -->
-    <SurfaceCard padding="lg" tone="background">
+    <SurfaceCard padding="lg" tone="background" glow>
       <OverlineLabel text={t('contact.connect.label')} class="mb-6" />
       <div class="flex flex-col gap-4">
         {socialData.links.map((link) => <SocialLinkItem link={link} />)}

--- a/src/scripts/border-glow.ts
+++ b/src/scripts/border-glow.ts
@@ -8,11 +8,9 @@
 // when the user has not requested reduced motion — on touch / a11y setups
 // the visual is disabled in CSS, so the JS work would be wasted.
 
-const canHover =
-  typeof window !== 'undefined' && window.matchMedia('(hover: hover)').matches;
+const canHover = typeof window !== 'undefined' && window.matchMedia('(hover: hover)').matches;
 const reducedMotion =
-  typeof window !== 'undefined' &&
-  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 if (canHover && !reducedMotion) {
   let pending: PointerEvent | null = null;

--- a/src/scripts/border-glow.ts
+++ b/src/scripts/border-glow.ts
@@ -2,41 +2,55 @@
 // Updates --glow-x / --glow-y CSS variables on `.border-glow` and
 // `.group-border-glow` elements as the pointer moves over them.
 //
-// Single document-level mousemove listener (event delegation), throttled
+// Single document-level pointermove listener (event delegation), throttled
 // with requestAnimationFrame so we touch the DOM at most once per frame.
+// The listener is only installed on devices that actually have hover and
+// when the user has not requested reduced motion — on touch / a11y setups
+// the visual is disabled in CSS, so the JS work would be wasted.
 
-let pending: PointerEvent | MouseEvent | null = null;
-let raf: number | null = null;
+const canHover =
+  typeof window !== 'undefined' && window.matchMedia('(hover: hover)').matches;
+const reducedMotion =
+  typeof window !== 'undefined' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-function setVars(el: HTMLElement, e: { clientX: number; clientY: number }): void {
-  const rect = el.getBoundingClientRect();
-  el.style.setProperty('--glow-x', `${e.clientX - rect.left}px`);
-  el.style.setProperty('--glow-y', `${e.clientY - rect.top}px`);
-}
+if (canHover && !reducedMotion) {
+  let pending: PointerEvent | null = null;
+  let raf: number | null = null;
 
-function flush(): void {
-  raf = null;
-  const e = pending;
-  pending = null;
-  if (!e) return;
-  const target = e.target;
-  if (!(target instanceof Element)) return;
-
-  const direct = target.closest<HTMLElement>('.border-glow');
-  if (direct) setVars(direct, e);
-
-  const group = target.closest<HTMLElement>('.group');
-  if (group) {
-    const inner = group.querySelector<HTMLElement>('.group-border-glow');
-    if (inner) setVars(inner, e);
+  function setVars(el: HTMLElement, e: PointerEvent): void {
+    const rect = el.getBoundingClientRect();
+    el.style.setProperty('--glow-x', `${e.clientX - rect.left}px`);
+    el.style.setProperty('--glow-y', `${e.clientY - rect.top}px`);
   }
-}
 
-window.addEventListener(
-  'pointermove',
-  (e: PointerEvent) => {
-    pending = e;
-    if (raf === null) raf = requestAnimationFrame(flush);
-  },
-  { passive: true },
-);
+  function flush(): void {
+    raf = null;
+    const e = pending;
+    pending = null;
+    if (!e) return;
+    const target = e.target;
+    if (!(target instanceof Element)) return;
+
+    const direct = target.closest<HTMLElement>('.border-glow');
+    if (direct) setVars(direct, e);
+
+    const group = target.closest<HTMLElement>('.group');
+    if (group) {
+      const inner = group.querySelector<HTMLElement>('.group-border-glow');
+      if (inner) setVars(inner, e);
+    }
+  }
+
+  window.addEventListener(
+    'pointermove',
+    (e: PointerEvent) => {
+      // Skip touch / pen — they don't drive a real hover state, so the
+      // CSS spotlight isn't visible anyway.
+      if (e.pointerType !== 'mouse') return;
+      pending = e;
+      if (raf === null) raf = requestAnimationFrame(flush);
+    },
+    { passive: true },
+  );
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -119,7 +119,7 @@
 /* ===========================
    Border Glow (hover only, cursor-tracked)
    A radial brand-gradient at (--glow-x, --glow-y) is mask-composited
-   into a 1px ring, so only the slice of border nearest the cursor lights
+   into a 2px ring, so only the slice of border nearest the cursor lights
    up. Position is updated by src/scripts/border-glow.ts.
    =========================== */
 @layer components {
@@ -129,7 +129,11 @@
     --glow-x: 50%;
     --glow-y: 50%;
     --glow-size: 260px;
-    transition: box-shadow 280ms ease;
+    /* Include box-shadow + color properties so call sites that compose
+       this with `transition-colors` keep both animations. */
+    transition-property: box-shadow, color, background-color, border-color;
+    transition-duration: 280ms;
+    transition-timing-function: ease;
   }
   .border-glow::before,
   .group-border-glow::before {
@@ -146,11 +150,15 @@
       rgba(182, 111, 255, 0.4) 55%,
       transparent 75%
     );
+    /* Firefox uses unprefixed `mask`; WebKit/Blink keep the -webkit- form */
+    mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
     -webkit-mask:
       linear-gradient(#fff 0 0) content-box,
       linear-gradient(#fff 0 0);
-    -webkit-mask-composite: xor;
     mask-composite: exclude;
+    -webkit-mask-composite: xor;
     /* Outward glow on the border ring itself */
     filter: drop-shadow(0 0 4px rgba(104, 109, 255, 0.55));
     opacity: 0;


### PR DESCRIPTION
## Summary

PR #33 のマージ後に Copilot レビュー（PR #34 上）から上がった 6 件の指摘に対応。

| # | 指摘 | 対応 |
|---|---|---|
| 1 | `.border-glow` の `transition: box-shadow` が、`transition-colors` を併用する呼び出し側でカスケード上書きされて box-shadow が animate しない可能性 | `transition-property` を `box-shadow, color, background-color, border-color` に拡張 |
| 2 | global `pointermove` がタッチ端末や reduced-motion でも常時走り、無駄に `getBoundingClientRect` を呼ぶ | `(hover: hover)` && !`prefers-reduced-motion` の時のみリスナー設置。さらに `pointerType !== 'mouse'` を早期 return |
| 3 | `pending` の型 `PointerEvent \| MouseEvent` が広すぎる | `PointerEvent \| null` に narrow（`setVars` も連動） |
| 4 | `glow` がデフォルト `true` のため、非 interactive な `<div>` カードまでホバーで光り「クリック可」誤認させる | デフォルトを `interactive \|\| as === 'a' \|\| as === 'article'` に変更。Contact 内の 2 枚は元仕様どおり光らせるため `glow` を明示 |
| 5 | コメントが "1px ring" だが実際は `padding: 2px` | コメントを "2px ring" に修正 |
| 6 | `-webkit-mask` のみで unprefixed `mask` を持たないため Firefox で全面オーバーレイ化する | `mask` と `mask-composite: exclude` を追加（`-webkit-` も並置） |

## Test plan
- [x] `bun run lint` 通過
- [x] `bun run build` 通過
- [ ] Firefox でホバー時にカードがオーバーレイで覆われない（ring のみ表示）
- [ ] タッチ端末で pointermove リスナーが install されない
- [ ] Contact 2 カードのホバー時に従来どおり border-glow が出る
- [ ] 非 interactive な div を SurfaceCard で作っても glow が出ない（明示 `glow` を渡さない限り）