### PR TITLE
fix: restore handwritten hero on production

### DIFF
--- a/src/components/hero/HandwrittenVision.tsx
+++ b/src/components/hero/HandwrittenVision.tsx
@@ -21,7 +21,10 @@ const VISION_STYLE: CSSProperties = {
   lineHeight: 1.2,
 };
 
-const CAVEAT_FONT_URL = `${import.meta.env.BASE_URL}fonts/caveat.ttf`;
+const normalizedBaseUrl = import.meta.env.BASE_URL.endsWith('/')
+  ? import.meta.env.BASE_URL
+  : `${import.meta.env.BASE_URL}/`;
+const CAVEAT_FONT_URL = `${normalizedBaseUrl}fonts/caveat.ttf`;
 const CAVEAT_BUNDLE = {
   ...caveat,
   fontUrl: CAVEAT_FONT_URL,


### PR DESCRIPTION
## Summary
- normalize BASE_URL before composing the Caveat font URL
- prevent malformed production path like /my_portfoliofonts/caveat.ttf
- keep handwritten hero rendering behavior unchanged otherwise

## Root Cause
BASE_URL can be /my_portfolio without a trailing slash in production. Direct string concatenation produced an invalid font URL and font loading failed.

## Validation
- bun run lint
- bun run build
