### PR TITLE
fix(a11y): MobileNav にフォーカス管理・Escape クローズ・フォーカストラップを追加

### DIFF
--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Menu, X } from 'lucide-react';
 import ThemeLangControls from '@/components/common/ThemeLangControls';
 
@@ -15,8 +15,77 @@ interface MobileNavProps {
   base: string;
 }
 
+/** Returns all keyboard-focusable elements inside a container. */
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  );
+}
+
 export default function MobileNav({ items, menuLabel, langLabel, lang, base }: MobileNavProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  // Guards the close-path focus return so it never fires on initial mount.
+  const wasOpenRef = useRef(false);
+
+  // Move focus into the menu when it opens; return to trigger when it closes.
+  useEffect(() => {
+    if (isOpen) {
+      wasOpenRef.current = true;
+      // Effects run after commit, so the menu is already in the DOM.
+      // (No rAF here: rAF callbacks never fire while the tab is hidden.)
+      if (menuRef.current) {
+        const focusable = getFocusableElements(menuRef.current);
+        focusable[0]?.focus();
+      }
+    } else if (wasOpenRef.current) {
+      wasOpenRef.current = false;
+      triggerRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  // Keyboard handling: Escape closes the menu; Tab/Shift+Tab cycle within.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setIsOpen(false);
+        return;
+      }
+
+      if (event.key === 'Tab' && menuRef.current) {
+        const focusable = getFocusableElements(menuRef.current);
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (event.shiftKey) {
+          if (document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen]);
+
+  function handleLinkClick() {
+    setIsOpen(false);
+  }
 
   return (
     <div className="md:hidden">
@@ -25,23 +94,29 @@ export default function MobileNav({ items, menuLabel, langLabel, lang, base }: M
 
         {/* Hamburger */}
         <button
+          ref={triggerRef}
           onClick={() => setIsOpen(!isOpen)}
           className="text-muted-foreground hover:text-foreground inline-flex h-9 w-9 items-center justify-center rounded-md transition-colors"
           aria-label={menuLabel}
           aria-expanded={isOpen}
+          aria-controls="mobile-nav-menu"
         >
           {isOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
         </button>
       </div>
 
       {isOpen && (
-        <div className="border-border bg-background/95 absolute top-16 left-0 w-full border-b backdrop-blur-md">
-          <nav className="mx-auto flex max-w-6xl flex-col px-6 py-4">
+        <div
+          ref={menuRef}
+          id="mobile-nav-menu"
+          className="border-border bg-background/95 absolute top-16 left-0 w-full border-b backdrop-blur-md"
+        >
+          <nav aria-label={menuLabel} className="mx-auto flex max-w-6xl flex-col px-6 py-4">
             {items.map((item) => (
               <a
                 key={item.href}
                 href={item.href}
-                onClick={() => setIsOpen(false)}
+                onClick={handleLinkClick}
                 className="text-muted-foreground hover:text-foreground py-3 text-sm transition-colors"
               >
                 {item.label}


### PR DESCRIPTION
Closes #50

## 概要

MobileNav はこれまで `aria-label` / `aria-expanded` のみ対応で、キーボード・スクリーンリーダー利用者への配慮が不足していました。本 PR でメニューの開閉に伴うフォーカス制御を完全対応します。

## 変更内容

| 項目 | Before | After |
|---|---|---|
| メニューを開く | フォーカスはトリガーに残る | メニュー内の最初のリンクへ移動 |
| Escape キー | 何も起きない | メニューを閉じてトリガーへフォーカス返却 |
| Tab / Shift+Tab | メニュー外へ抜ける | メニュー内で循環（フォーカストラップ） |
| 閉じる（全経路） | フォーカス迷子 | トリガーボタンへ返却 |
| ARIA | `aria-expanded` のみ | `aria-controls` / メニュー `id` / `nav aria-label` を追加 |

実装は plain React（refs + effects、document レベル keydown リスナー）で、新規依存なし。

### 実装上の注意点

- **初回マウント時のフォーカス奪取防止**: close 時のフォーカス返却は `wasOpenRef` でガードし、ページ読み込み時にハンバーガーへフォーカスが飛ばないようにした
- **rAF 不使用**: React の effect は DOM コミット後に走るため直接 `focus()` する。`requestAnimationFrame` は非表示タブで発火しないため使わない

## 検証（ブラウザ実測: 375px モバイルビューポート）

```
afterLoad:   { focusStolenOnLoad: false, activeElement: BODY }
afterOpen:   { menuOpen: true, focusOnFirstLink: true, activeLinkText: "About" }
afterTabWrap:{ wrappedToFirst: true }
afterEscape: { menuClosed: true, focusReturnedToTrigger: true }
```

- `bun run lint` → exit 0 / `bun run build` → exit 0（3 pages）
- 現行ページの console エラー 0（ログ上の hydration エラーは base path なし URL での初回ロード時の累積分）

## 受け入れ基準の照合（issue #50）

- ✅ WHEN メニューを開いて Escape を押した THE SYSTEM SHALL メニューを閉じてトリガーボタンにフォーカスを戻す
- ✅ WHEN メニューを開いた THE SYSTEM SHALL フォーカスをメニュー内の最初のリンクに移動する